### PR TITLE
Feature/add acknowledge

### DIFF
--- a/config/compe2022.yaml
+++ b/config/compe2022.yaml
@@ -1,3 +1,4 @@
 #********** Driver Parameters ************
 
-/proc_underwater_com/settings/number_mission : 16
+/proc_underwater_com/settings/number_mission : 11
+/proc_underwater_com/settings/delay_ack : 5

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>proc_underwater_com</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <description>The proc_underwater_com package</description>
 
   <maintainer email="francisalonzo29@gmail.com">Francis Alonzo</maintainer>

--- a/src/Configuration.cc
+++ b/src/Configuration.cc
@@ -45,7 +45,7 @@ namespace proc_underwater_com
 
         FindParameter("/settings/number_mission", nbmissions);
         FindParameter("/settings/id", id);
-        FindParameter("settings/delay_ac", delay_ack);
+        FindParameter("/settings/delay_ack", delay_ack);
 
         ROS_INFO("End deserialize params");
     }

--- a/src/Configuration.cc
+++ b/src/Configuration.cc
@@ -31,7 +31,8 @@ namespace proc_underwater_com
     Configuration::Configuration(const ros::NodeHandlePtr &nh)
         : nh(nh),
           nbmissions(16),
-          id(8)
+          id(8),
+          delay_ack(5)
     {
         Deserialize();
     }
@@ -44,6 +45,7 @@ namespace proc_underwater_com
 
         FindParameter("/settings/number_mission", nbmissions);
         FindParameter("/settings/id", id);
+        FindParameter("settings/delay_ac", delay_ack);
 
         ROS_INFO("End deserialize params");
     }

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -41,6 +41,7 @@ namespace proc_underwater_com
 
         int getNumberMission() const {return nbmissions;}
         int getNumberid() const {return id;}
+        int getDelayAck() const {return delay_ack;}
 
     private:
 
@@ -48,6 +49,7 @@ namespace proc_underwater_com
 
         int nbmissions;
         int id;
+        int delay_ack;
 
         void Deserialize();
         void SetParameter();

--- a/src/SharedQueue.h
+++ b/src/SharedQueue.h
@@ -1,0 +1,116 @@
+#ifndef INTERFACE_RS485_SHAREDQUEUE_H
+#define INTERFACE_RS485_SHAREDQUEUE_H
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+template <typename T>
+class SharedQueue
+{
+public:
+    SharedQueue();
+    ~SharedQueue();
+
+    T& front();
+    void pop_front();
+
+    T get_n_pop_front();
+
+    void push_back(const T& item);
+    void push_back(T&& item);
+
+
+    unsigned long size();
+    bool empty();
+
+private:
+    std::deque<T> queue_;
+    std::mutex mutex_;
+    std::condition_variable cond_;
+};
+
+template <typename T>
+SharedQueue<T>::SharedQueue(){}
+
+template <typename T>
+SharedQueue<T>::~SharedQueue(){}
+
+template <typename T>
+T& SharedQueue<T>::front()
+{
+    std::unique_lock<std::mutex> mlock(mutex_);
+    while (queue_.empty())
+    {
+        cond_.wait(mlock);
+    }
+    return queue_.front();
+}
+
+template <typename T>
+void SharedQueue<T>::pop_front()
+{
+    std::unique_lock<std::mutex> mlock(mutex_);
+    while (queue_.empty())
+    {
+        cond_.wait(mlock);
+    }
+    queue_.pop_front();
+}
+
+template <typename T>
+T SharedQueue<T>::get_n_pop_front()
+{
+    std::unique_lock<std::mutex> mlock(mutex_);
+    while (queue_.empty())
+    {
+        cond_.wait(mlock);
+    }
+    T temp = queue_.front();
+    queue_.pop_front();
+    mlock.unlock();
+    cond_.notify_one();
+    return temp;
+}
+
+template <typename T>
+void SharedQueue<T>::push_back(const T& item)
+{
+    std::unique_lock<std::mutex> mlock(mutex_);
+    queue_.push_back(item);
+    mlock.unlock();     // unlock before notificiation to minimize mutex con
+    cond_.notify_one(); // notify one waiting thread
+
+}
+
+template <typename T>
+void SharedQueue<T>::push_back(T&& item)
+{
+    std::unique_lock<std::mutex> mlock(mutex_);
+    queue_.push_back(std::move(item));
+    mlock.unlock();     // unlock before notificiation to minimize mutex con
+    cond_.notify_one(); // notify one waiting thread
+
+}
+
+template <typename T>
+unsigned long SharedQueue<T>::size()
+{
+    std::unique_lock<std::mutex> mlock(mutex_);
+    unsigned long size = queue_.size();
+    mlock.unlock();
+    cond_.notify_one();
+    return size;
+}
+
+template <typename T>
+bool SharedQueue<T>::empty()
+{
+    std::unique_lock<std::mutex> mlock(mutex_);
+    bool empty = queue_.empty();
+    mlock.unlock();
+    cond_.notify_one();
+    return empty;
+}
+
+#endif //INTERFACE_RS485_SHAREDQUEUE_H

--- a/src/proc_underwater_com_node.cc
+++ b/src/proc_underwater_com_node.cc
@@ -256,7 +256,16 @@ namespace proc_underwater_com
     {
         if(uint16_t(msg.data.size()) == uint16_t(configuration_.getNumberMission()))
         {
-            mission_state.data = msg.data;
+            if(stoi(msg.layout.dim[0].label) == AUVID)
+            {
+                ROS_INFO_STREAM("Submarine mission list updated.");
+                mission_state.data = msg.data;
+            }
+            else
+            {
+                ROS_INFO_STREAM("Other submarine mission list updated.");
+                other_sub_mission_state.data = msg.data;
+            }
         }
         else
         {
@@ -294,12 +303,14 @@ namespace proc_underwater_com
         otherauvMissionPublisher_.publish(other_sub_mission_state); 
     }
 
-    int8_t ProcUnderwaterComNode::VerifyPacket(const Modem_M64_t packet){
-        
-        if(packet.AUV_ID == 7 || packet.AUV_ID == 8 ){
+    int8_t ProcUnderwaterComNode::VerifyPacket(const Modem_M64_t packet)
+    {    
+        if(packet.AUV_ID == 7 || packet.AUV_ID == 8 )
+        {
             return 1;
         } 
-        else{
+        else
+        {
             return 0;
         }
     }

--- a/src/proc_underwater_com_node.cc
+++ b/src/proc_underwater_com_node.cc
@@ -46,9 +46,13 @@ namespace proc_underwater_com
         syncPublisher_ =  nh_->advertise<std_msgs::Bool>("/proc_underwater_com/sync_requested", 100);
         DepthPublisher_ =  nh_->advertise<std_msgs::Float32>("/proc_underwater_com/other_sub_depth", 100);
 
-        // Service
+        // Services
         depthSrv_ = nh_->advertiseService("/proc_underwater_com/depth_request", &ProcUnderwaterComNode::DepthRequest, this);
         underwaterComClient_ = nh_->serviceClient<sonia_common::ModemSendCmd>("/provider_underwater_com/request");
+
+        // Threads
+        interpretMessage_ = std::thread(std::bind(&ProcUnderwaterComNode::UnderwaterComInterpreter, this));
+        sendMessageToSensor_ = std::thread(std::bind(&ProcUnderwaterComNode::SendMessageToSensor, this));
 
         InitMissionState(configuration_.getNumberMission());
         AUVID = configuration_.getNumberid();
@@ -58,7 +62,10 @@ namespace proc_underwater_com
     }
 
     // Node Destructor
-    ProcUnderwaterComNode::~ProcUnderwaterComNode(){}
+    ProcUnderwaterComNode::~ProcUnderwaterComNode()
+    {
+        stop_thread = true;
+    }
 
     // Spin
     void ProcUnderwaterComNode::Spin()
@@ -71,75 +78,148 @@ namespace proc_underwater_com
             r.sleep();
         }
     }
-
     void ProcUnderwaterComNode::UnderwaterComInterpreterCallback(const std_msgs::UInt64 &msg)
     {
-        Modem_M64_t packet = ConstructPacket(msg.data);
+        ROS_DEBUG_STREAM("Received message");
+        queue.push_back(msg.data);
+    }
+
+    void ProcUnderwaterComNode::UnderwaterComInterpreter()
+    {
+        Modem_M64_t packet;
         float_t auvDepth = 0;
         uint32_t temp = 0;
-        uint8_t read_write = packet.rec_send;
-        uint8_t data[] = {packet.data[0], packet.data[1], packet.data[2], packet.data[3]};
+        uint8_t read_write = 0;
+        uint8_t data[] = {0,0,0,0,0,0};
 
-        if(VerifyPacket(packet))
+        while(!stop_thread)
         {
-            if(read_write == 1)
+            if(!queue.empty())
             {
-                switch (packet.cmd)
+                packet = ConstructPacket(queue.get_n_pop_front());
+                auvDepth = 0;
+                temp = 0;
+                read_write = packet.rec_send;
+                
+                for(uint8_t i = 0; i < 4; ++i)
                 {
-                    case mission: 
-                        UpdateMissionState_othersub(packet.data[0], packet.data[1]);
-                        SendAckknowledge(packet.cmd);
-                        break;
-                    case depth:
-                        //request depth from other sub
-                        SendDepth();
-                        break;
-                    case sync: 
-                        AuvSyncInterpreter(packet.rec_send);
-                        SendAckknowledge(packet.cmd);
-                        break;
-                    default:
-                        ROS_WARN_STREAM("Unknown command received: No action associated");
-                        break;
+                    data[i] = packet.data[i];
                 }
-            }
-            else if(read_write == 0)
-            {
-                switch (packet.cmd)
+
+                if(VerifyPacket(packet))
                 {
-                    case mission:
-                        break;
-                    case depth:
-                        //receive depth from other sub and publish it
-                        memcpy(&temp,&data, sizeof(uint32_t));
-                        auvDepth = (float_t)temp / 100.0;
-                        AuvDepthInterpreter(auvDepth);
-                        break;
-                    case sync:
-                        break;
-                    case ack:
-                        if(data[0] == mission)
+                    if(read_write == 1)
+                    {
+                        switch (packet.cmd)
                         {
-                            ROS_INFO_STREAM("Received acknowledge for mission.");
-                            ackknowledge_mission_completed_ = 0;
+                            case mission: 
+                                UpdateMissionState_othersub(packet.data[0], packet.data[1]);
+                                SendAckknowledge(packet.cmd);
+                                break;
+                            case depth:
+                                //request depth from other sub
+                                SendDepth();
+                                break;
+                            case sync: 
+                                AuvSyncInterpreter(packet.rec_send);
+                                SendAckknowledge(packet.cmd);
+                                break;
+                            default:
+                                ROS_WARN_STREAM("Unknown command received: No action associated");
+                                break;
                         }
-                        else if(data[0] == sync)
+                    }
+                    else if(read_write == 0)
+                    {
+                        switch (packet.cmd)
                         {
-                            ackknowledge_sync_completed_ = 0;
+                            case mission:
+                                break;
+                            case depth:
+                                //receive depth from other sub and publish it
+                                memcpy(&temp,&data, sizeof(uint32_t));
+                                auvDepth = (float_t)temp / 100.0;
+                                AuvDepthInterpreter(auvDepth);
+                                break;
+                            case sync:
+                                break;
+                            case ack:
+                                if(data[0] == mission)
+                                {
+                                    ackknowledge_mission_completed_ = 0;
+                                }
+                                else if(data[0] == sync)
+                                {
+                                    ackknowledge_sync_completed_ = 0;
+                                }
+                                else
+                                {
+                                    ROS_DEBUG_STREAM("No acknowledge required for this command.");
+                                }
+                                break;
+                            default:
+                                ROS_WARN_STREAM("Unknown command received: No action associated");
+                                break;
                         }
-                        else
-                        {
-                            ROS_DEBUG_STREAM("No acknowledge required for this command.");
-                        }
-                        break;
-                    default:
-                        ROS_WARN_STREAM("Unknown command received: No action associated");
-                        break;
+                    }
+                    else
+                    {
+                        ROS_ERROR_STREAM("Error with the packet. Dropping packet");
+                    }
                 }
             }
             else
             {
-                ROS_ERROR_STREAM("Error with the packet. Dropping packet");
+                ros::Duration(0.1).sleep(); //ROSPARAM TO DO
+            }
+        }
+    }
+
+    void ProcUnderwaterComNode::SendMessageToSensor()
+    {
+        Modem_M64_t packet;
+        std_msgs::UInt64 msg;
+        std::chrono::seconds wait_period(configuration_.getDelayAck());
+
+        while(!stop_thread)
+        {
+            if(!sendQueue_.empty())
+            {
+                packet = sendQueue_.get_n_pop_front();
+                if(packet.cmd == mission)
+                {
+                    ackknowledge_mission_completed_++;
+                    msg.data = DeconstructPacket(packet);
+                    ROS_DEBUG_STREAM("Mutex acquired for mission and waiting on feedback");
+                    while(ackknowledge_mission_completed_ != 0)
+                    {
+                        underwaterComPublisher_.publish(msg);
+                        std::this_thread::sleep_for(wait_period);
+                    }
+                    ROS_DEBUG_STREAM("Mutex release for mission");
+                }
+                else if(packet.cmd == sync)
+                {
+                    ackknowledge_sync_completed_++;
+                    msg.data = DeconstructPacket(packet);
+                    ROS_DEBUG_STREAM("Mutex acquired for sync and waiting on feedback");
+                    while(ackknowledge_sync_completed_ != 0)
+                    {
+                        underwaterComPublisher_.publish(msg);
+                        std::this_thread::sleep_for(wait_period);
+                    }
+                    ROS_DEBUG_STREAM("Mutex release for sync");
+                }
+                else
+                {
+                    ROS_DEBUG_STREAM("Cmd doesn't require a acknowledge.");
+                    msg.data = DeconstructPacket(packet);
+                    underwaterComPublisher_.publish(msg);
+                }
+            }
+            else
+            {
+                ros::Duration(0.1).sleep(); //ROSPARAM TO DO
             }
         }
     }
@@ -224,34 +304,8 @@ namespace proc_underwater_com
         }
     }
 
-    bool ProcUnderwaterComNode::SendMessageToSensor(const std_msgs::UInt64 &msg, uint8_t cmd)
+    void ProcUnderwaterComNode::AuvSyncInterpreter(const bool state)
     {
-        if(cmd == mission)
-        {
-            ackknowledge_mission_mutex_.lock();
-            ackknowledge_mission_completed_++;
-            ROS_INFO_STREAM("Mutex acquired for mission and waiting on feedback");
-            while(ackknowledge_mission_completed_ != 0)
-            {
-                underwaterComPublisher_.publish(msg);
-                ros::Duration(configuration_.getDelayAck()).sleep();
-            }
-            ackknowledge_mission_mutex_.unlock();
-            ROS_INFO_STREAM("Mutex release for mission");
-        }
-        else if(cmd == sync)
-        {
-
-        }
-        else
-        {
-            ROS_DEBUG_STREAM("Cmd doesn't require a acknowledge.");
-            underwaterComPublisher_.publish(msg);
-        }
-        return true;
-    }
-
-    void ProcUnderwaterComNode::AuvSyncInterpreter(const bool state){
         std_msgs::Bool sync_status;
         sync_status.data = state;
         syncPublisher_.publish(sync_status);
@@ -260,16 +314,14 @@ namespace proc_underwater_com
     void ProcUnderwaterComNode::MissionStateCallback(const sonia_common::ModemUpdateMissionList &msg)
     {      
         Modem_M64_t send_packet;
-        std_msgs::UInt64 send_msg;
 
         send_packet.AUV_ID = AUVID; 
         send_packet.cmd = mission;
         send_packet.data[0] = msg.mission_id;
         send_packet.data[1] = msg.mission_state;
 
-        send_msg.data = DeconstructPacket(send_packet);
         UpdateMissionState(msg.mission_id,msg.mission_state);
-        SendMessageToSensor(send_msg, mission);
+        sendQueue_.push_back(send_packet);
      }
 
     void ProcUnderwaterComNode::SyncCallback(const std_msgs::Bool &msg)
@@ -277,36 +329,30 @@ namespace proc_underwater_com
         if (msg.data == true)
         {
             Modem_M64_t send_packet;
-            std_msgs::UInt64 send_msg;
 
             send_packet.AUV_ID = AUVID; 
             send_packet.cmd = sync;
             send_packet.rec_send = 1;
 
-            send_msg.data = DeconstructPacket(send_packet);
-            SendMessageToSensor(send_msg, sync);
+            sendQueue_.push_back(send_packet);
         }
     }
 
     bool ProcUnderwaterComNode::DepthRequest(std_srvs::Empty::Request &DepthRsq, std_srvs::Empty::Response &DepthRsp)
     {    
         Modem_M64_t send_packet;
-        std_msgs::UInt64 send_msg;
 
         send_packet.AUV_ID = AUVID; 
         send_packet.cmd = depth;
         send_packet.rec_send = 1;
 
-        send_msg.data = DeconstructPacket(send_packet);
-        underwaterComPublisher_.publish(send_msg);
-
+        sendQueue_.push_back(send_packet);
         return true;
     }
 
     void ProcUnderwaterComNode::SendDepth()
     {
         Modem_M64_t send_packet;
-        std_msgs::UInt64 send_msg;
         uint8_t data[4] = {0,0,0,0};
         uint32_t auvDepth;
         auvDepth = lastDepth_ * 100.0; 
@@ -321,8 +367,7 @@ namespace proc_underwater_com
         send_packet.data[2]=data[2];
         send_packet.data[3]=data[3];
 
-        send_msg.data = DeconstructPacket(send_packet);
-        underwaterComPublisher_.publish(send_msg);
+        sendQueue_.push_back(send_packet);
     }
 
     void ProcUnderwaterComNode::SendAckknowledge(uint8_t cmd)
@@ -339,6 +384,7 @@ namespace proc_underwater_com
         send_packet.data[3]=0;
 
         send_msg.data = DeconstructPacket(send_packet);
+        // Here we bypass the send thread to make sure that we don't get a deadlock
         underwaterComPublisher_.publish(send_msg);
     }
 
@@ -346,7 +392,7 @@ namespace proc_underwater_com
     {
         if(cmd == mission)
         {
-            ROS_INFO_STREAM("Received acknowledge for mission.");
+            ROS_DEBUG_STREAM("Received acknowledge for mission.");
             ackknowledge_mission_completed_--;
         }
         else if(cmd == sync)

--- a/src/proc_underwater_com_node.h
+++ b/src/proc_underwater_com_node.h
@@ -30,18 +30,15 @@
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float32.h>
 #include <std_msgs/UInt64.h>
-#include <std_msgs/UInt8MultiArray.h>
 #include <std_msgs/Int8MultiArray.h>
 #include <std_srvs/Empty.h>
-#include <string>
 #include <thread>
 #include <mutex>
-#include <algorithm>
-#include <iterator>
-#include <errno.h>
+#include <chrono>
 
 #include "Configuration.h"
 #include "modem_data.h"
+#include "SharedQueue.h"
 #include <sonia_common/Modem_Definitions.h>
 #include <sonia_common/ModemSendCmd.h>
 #include <sonia_common/ModemUpdateMissionList.h>
@@ -64,6 +61,8 @@ class ProcUnderwaterComNode
     private:
 
         void UnderwaterComInterpreterCallback(const std_msgs::UInt64 &msg);
+        void UnderwaterComInterpreter(); // Thread function
+        void SendMessageToSensor(); // Thread function
         bool SensorState(sonia_common::ModemSendCmd &srv);
 
         void AuvStateMissionInterpreter(const bool state);
@@ -81,8 +80,7 @@ class ProcUnderwaterComNode
         Modem_M64_t ConstructPacket(const uint64_t data);
         uint64_t DeconstructPacket(const Modem_M64_t packet);
         int8_t VerifyPacket(const Modem_M64_t packet);
-        bool SendMessageToSensor(const std_msgs::UInt64 &msg, uint8_t cmd);
-
+        
         void InitMissionState(uint8_t size);
         void UpdateMissionState(uint8_t index, int8_t state);
         void UpdateMissionState_othersub(uint8_t index, int8_t state);
@@ -108,24 +106,25 @@ class ProcUnderwaterComNode
         ros::ServiceClient underwaterComClient_;
         ros::ServiceServer depthSrv_;
 
-        std::thread process_thread;
-        std::mutex sensor_mutex;
-
         std_msgs::Bool stateMission_; 
         std_msgs::Float32 depth_;
+
+        std::thread interpretMessage_;
+        std::thread sendMessageToSensor_;
+        bool stop_thread = false;
+        SharedQueue<uint64_t> queue;
+        SharedQueue<Modem_M64_t> sendQueue_;
 
         // Refer to read me to understand the use for it
         std_msgs::Int8MultiArray mission_state;
         std_msgs::Int8MultiArray other_sub_mission_state;
         uint8_t AUVID = 0;
-        float lastDepth_;
-        float other_sub_depth_;
+        float lastDepth_ = 0;
+        float other_sub_depth_ = 0;
 
         // For syncing message
         uint8_t ackknowledge_mission_completed_;
-        std::mutex ackknowledge_mission_mutex_;
         uint8_t ackknowledge_sync_completed_;
-        std::mutex ackknowledge_sync_mutex_;
 };
 }
 

--- a/src/proc_underwater_com_node.h
+++ b/src/proc_underwater_com_node.h
@@ -35,6 +35,7 @@
 #include <thread>
 #include <mutex>
 #include <chrono>
+#include <string>
 
 #include "Configuration.h"
 #include "modem_data.h"

--- a/src/proc_underwater_com_node.h
+++ b/src/proc_underwater_com_node.h
@@ -39,7 +39,6 @@
 #include <algorithm>
 #include <iterator>
 #include <errno.h>
-#include <atomic>
 
 #include "Configuration.h"
 #include "modem_data.h"
@@ -51,7 +50,7 @@
 
 namespace proc_underwater_com {
 
-enum command {mission,depth, sync, ack};
+enum command {mission, depth, sync, ack};
 
 class ProcUnderwaterComNode
 {
@@ -123,9 +122,9 @@ class ProcUnderwaterComNode
         float other_sub_depth_;
 
         // For syncing message
-        std::atomic<std::uint8_t> ackknowledge_mission_completed_;
+        uint8_t ackknowledge_mission_completed_;
         std::mutex ackknowledge_mission_mutex_;
-        std::atomic<std::uint8_t> ackknowledge_sync_completed_;
+        uint8_t ackknowledge_sync_completed_;
         std::mutex ackknowledge_sync_mutex_;
 };
 }


### PR DESCRIPTION
**Warning :** Before creating a pull request, make sure that it does not already exists in the [pull requests](../). Thank you.

## Description
To support bi directionnal communication with acknowledge, some threads have been created for the send and receive since ROS callbacks are not actual thread and are blocking new messages from entering. So, the threads are using a sharedQueue for the sent and received message. 

Also, the init / reset has been redone to include a method to initialise both array at the start of a mission.

## How has this been tested ?
Tested locally. More test will be done with the submarines.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings